### PR TITLE
support "/" in topic path

### DIFF
--- a/Rebus.AzureServiceBus/AsbStringExtensions.cs
+++ b/Rebus.AzureServiceBus/AsbStringExtensions.cs
@@ -13,7 +13,7 @@ namespace Rebus.AzureServiceBus
         public static string ToValidAzureServiceBusEntityName(this string topic)
         {
             return string.Concat(topic
-                .Select(c => char.IsLetterOrDigit(c) ? char.ToLower(c) : '_'));
+                .Select(c => char.IsLetterOrDigit(c) || c == '/' ? char.ToLower(c) : '_'));
         }
     }
 }

--- a/Rebus.AzureServiceBus/AzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBusTransport.cs
@@ -591,7 +591,8 @@ namespace Rebus.AzureServiceBus
 
         string GetSubscriptionName()
         {
-            return _inputQueueAddress.ToValidAzureServiceBusEntityName();
+            var idx = _inputQueueAddress.LastIndexOf("/", StringComparison.Ordinal) + 1;
+            return _inputQueueAddress.Substring(idx).ToValidAzureServiceBusEntityName();
         }
 
         void VerifyIsOwnInputQueueAddress(string subscriberAddress)


### PR DESCRIPTION
Azure Service Bus supports "/" in topic and queue paths, with that which comes before the "/" acting as a virtual directory.  These are handy for better organizing groups of topics/queues in ASB, or supporting multiple environments per ASB namespace(dev, integration, staging, etc), when coupled with a decorator, and the visual representation is useful when using Service Bus Explorer(see screenshot below).  The proposed changes alter the normalization of an ASB entity name not replacing a "/" with an underscore.  I don't believe there are any issues in doing this as a "/" should not show up in a type's assembly-qualified name.  

Also, the determination of a subscription is altered so that it evaluates input queue address and pulls everything after the last slash as a slash is an invalid character in a subscription name.  With the changes organizing topics by environment can be accomplished with the following setup.

publisher
```
class Program
    {
        static void Main(string[] args)
        {

            var activator = new BuiltinHandlerActivator();

            var bus = Configure.With(activator)
                .Transport(t => t.UseAzureServiceBusAsOneWayClient("Endpoint=sb://conn"))
                .Options(o =>
                {
                    o.SimpleRetryStrategy(errorQueueAddress: "dev/errors");
                    o.OrganizeSubscriptionsByEnvironment("dev");
                })
                .Start();

            bus.Publish(new BusEvent("Here is a value")).Wait();
        }
    }
```
subscriber
```
class Program
    {
        static void Main(string[] args)
        {
            
            var activator = new BuiltinHandlerActivator();
            activator.Register(() => new EventBusHandler());

            var bus = Configure.With(activator)
                .Transport(t => t.UseAzureServiceBus("Endpoint=sb://conn", "dev/testreceiver1"))
                .Options(o =>
                {
                    o.SimpleRetryStrategy(errorQueueAddress: "dev/errors");
                    o.OrganizeSubscriptionsByEnvironment("dev");
                })
                .Start();

            bus.Subscribe<BusEvent>();

            Console.WriteLine("Press enter to quit");
            Console.ReadLine();
        }
    }


```

extension and decorator
```
public static class Ext
    {
        public static void OrganizeSubscriptionsByEnvironment(this OptionsConfigurer configurer, string environment)
        {
            configurer.Decorate<ISubscriptionStorage>(context =>
            {
                var ss = context.Get<ISubscriptionStorage>();
                var decorator = new EnviromentSubscriptionDecorator(ss, environment);
                return decorator;
            });
        }

    }

    public class EnviromentSubscriptionDecorator : ISubscriptionStorage
    {

        private readonly ISubscriptionStorage _toDecorate;
        private readonly string _environment;

        public EnviromentSubscriptionDecorator(ISubscriptionStorage toDecorate, string environment)
        {
            _toDecorate = toDecorate;
            _environment = environment;
        }

        public async Task<string[]> GetSubscriberAddresses(string topic)
        {
            var safeTopicName = string.Concat(topic
                .Select(c => char.IsLetterOrDigit(c) ? char.ToLower(c) : '_'));

            var returnable = $"subscription/{_environment}/{safeTopicName}";

            return new string[] { returnable };

        }

        public Task RegisterSubscriber(string topic, string subscriberAddress)
        {
            return _toDecorate.RegisterSubscriber($"{_environment}/{topic}", subscriberAddress);
        }

        public Task UnregisterSubscriber(string topic, string subscriberAddress)
        {
            return _toDecorate.UnregisterSubscriber($"{_environment}/{topic}", subscriberAddress);
        }

        public bool IsCentralized => _toDecorate.IsCentralized;

    }
```

Providing this effect while administering ASB through Service Bus Explorer.
![image](https://cloud.githubusercontent.com/assets/9484306/20724763/7c255bc2-b63d-11e6-9368-7da2dad45489.png)

If the code changes aren't acceptable I can accomplish the same by completely overriding the subscription storage with the decorator, but the proposed changes make the decorator pretty slim.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

