### PR TITLE
This resolves #30, shared access policy with manage permission is always required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@
 
 * Update Azure Service Bus dependency to 3.2.1
 
+## 6.0.7
+
+* Fix bug that would result in always require a manage permission in the shared access policy, even if the queues were already created
+
 
 [lezzi]: https://github.com/lezzi
 [Meyce]: https://github.com/Meyce

--- a/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
@@ -287,6 +287,12 @@ namespace Rebus.AzureServiceBus
 
         void CheckInputQueueConfiguration(string address)
         {
+            if (DoNotCheckQueueConfigurationEnabled)
+            {
+                _log.Info("Transport configured to not check queue configuration - skipping existence check for {queueName}", address);
+                return;
+            }
+
             AsyncHelpers.RunSync(async () =>
             {
                 var queueDescription = await GetQueueDescription(address).ConfigureAwait(false);
@@ -654,6 +660,11 @@ namespace Rebus.AzureServiceBus
         /// Gets/sets whether to skip creating queues
         /// </summary>
         public bool DoNotCreateQueuesEnabled { get; set; }
+
+        /// <summary>
+        /// Gets/sets whether to skip checking queues configuration
+        /// </summary>
+        public bool DoNotCheckQueueConfigurationEnabled { get; set; }
 
         /// <summary>
         /// Gets/sets the default message TTL. Must be set before calling <see cref="Initialize"/>, because that is the time when the queue is (re)configured

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
@@ -78,6 +78,7 @@ namespace Rebus.Config
                     transport.AutomaticallyRenewPeekLock = settings.AutomaticPeekLockRenewalEnabled;
                     transport.PartitioningEnabled = settings.PartitioningEnabled;
                     transport.DoNotCreateQueuesEnabled = settings.DoNotCreateQueuesEnabled;
+                    transport.DoNotCheckQueueConfigurationEnabled = settings.DoNotCheckQueueConfigurationEnabled;
                     transport.DefaultMessageTimeToLive = settings.DefaultMessageTimeToLive;
                     transport.LockDuration = settings.LockDuration;
                     transport.AutoDeleteOnIdle = settings.AutoDeleteOnIdle;

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
@@ -13,6 +13,7 @@ namespace Rebus.Config
         internal bool PartitioningEnabled { get; set; }
         internal bool DoNotCreateQueuesEnabled { get; set; }
         internal bool AutomaticPeekLockRenewalEnabled { get; set; }
+        internal bool DoNotCheckQueueConfigurationEnabled { get; set; }
         internal TimeSpan? DefaultMessageTimeToLive { get; set; }
         internal TimeSpan? LockDuration { get; set; }
         internal TimeSpan? AutoDeleteOnIdle { get; set; }
@@ -121,6 +122,18 @@ namespace Rebus.Config
         public AzureServiceBusTransportSettings DoNotCreateQueues()
         {
             DoNotCreateQueuesEnabled = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Skips queue configuration checks. Can be used when the connection string does not have manage rights to the queue object, e.g.
+        /// when a read-only shared-access signature is used to access an input queue. Please note that the signature MUST
+        /// have write access to the configured error queue, unless Azure Service Bus' own dead-lettering is activated on the 
+        /// input queue (which is probably the preferred approach with this option)
+        /// </summary>
+        public AzureServiceBusTransportSettings DoNotCheckQueueConfiguration()
+        {
+            DoNotCheckQueueConfigurationEnabled = true;
             return this;
         }
     }


### PR DESCRIPTION
where a shared access policy with a manage permission is no longer required if the queue is already created.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
