### PR TITLE
Added transport setting for overriding the Receive OperationTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 * Fix bug that would result in always require a manage permission in the shared access policy, even if the queues were already created - thanks [ehabelgindy]
 
 
-## 7.0.0-a10
+## 7.0.0-a11
 
 * Several adjustments to how queue names are validated and how topic names are generated. Please note that this is a BREAKING CHANGE, because queue names and topic names are no longer automatically lowercased (because it's not necessary), and topic names can now have . in them (because that has always been possible). If you update to 7, you must update ALL of your endpoints, otherwise pub/sub will not work!
 * Fix bug that would "forget" to stop automatic peek lock renewal in cases where message handler throws an exception, generating unnecessary noise in the log
@@ -82,6 +82,7 @@
 * Fix one-way client legacy naming bug (one-way client would not adhere to legacy naming convention, even when `.UseLegacyNaming()` was called on the configuration builder)
 * Default to using topics nested beneath their assemblies, so e.g. `await bus.Subscribe<string>()` will result in the creation of a topic named `mscorlib/System.String`, which will be formatted as a topic named `System.String` nested beneat `mscorlib` in tool that support it
 * Pluggable naming strategy via `INameFormatter`, allowing for customizing all aspects of how e.g. .NET types are named when creating topics from them, how queue names are normalized/sanitized, etc. - thanks [jr01]
+* Added transport setting for overriding the Receive OperationTimeout
 
 [ehabelgindy]: https://github.com/ehabelgindy
 [jr01]: https://github.com/jr01

--- a/Rebus.AzureServiceBus.Tests/AzureServiceBusDoNotCreateQueue.cs
+++ b/Rebus.AzureServiceBus.Tests/AzureServiceBusDoNotCreateQueue.cs
@@ -23,22 +23,15 @@ namespace Rebus.AzureServiceBus.Tests
         [Test]
         [TestCase(5)]
         [TestCase(10)]
-        [Ignore("Don't think this is relevant anymore, as it doesn't seem like the new client supports specifying a receive timeout in the connection string")]
         public async Task DoesntIgnoreDefinedTimeoutWhenReceiving(int operationTimeoutInSeconds)
         {
             var operationTimeout = TimeSpan.FromSeconds(operationTimeoutInSeconds);
 
             var connString = AsbTestConfig.ConnectionString;
-            var builder = new ServiceBusConnectionStringBuilder(connString)
-            {
-                //    OperationTimeout = operationTimeout,
-            };
-
-            var newConnString = builder.ToString();
 
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);
-            var transport = new AzureServiceBusTransport(newConnString, QueueName, consoleLoggerFactory, new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultNameFormatter());
-
+            var transport = new AzureServiceBusTransport(connString, QueueName, consoleLoggerFactory, new TplAsyncTaskFactory(consoleLoggerFactory), new DefaultNameFormatter());
+            transport.ReceiveOperationTimeout = TimeSpan.FromSeconds(operationTimeoutInSeconds);
             Using(transport);
 
             transport.Initialize();
@@ -50,7 +43,7 @@ namespace Rebus.AzureServiceBus.Tests
             var senderActivator = new BuiltinHandlerActivator();
 
             var senderBus = Configure.With(senderActivator)
-                .Transport(t => t.UseAzureServiceBus(newConnString, "sender"))
+                .Transport(t => t.UseAzureServiceBus(connString, "sender"))
                 .Start();
 
             Using(senderBus);

--- a/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
@@ -62,7 +62,6 @@ namespace Rebus.AzureServiceBus
         readonly CancellationToken _cancellationToken;
         readonly ManagementClient _managementClient;
         readonly string _connectionString;
-        readonly TimeSpan? _receiveTimeout;
         readonly ILog _log;
         readonly string _subscriptionName;
 
@@ -97,10 +96,6 @@ namespace Rebus.AzureServiceBus
             _cancellationToken = cancellationToken;
             _log = rebusLoggerFactory.GetLogger<AzureServiceBusTransport>();
             _managementClient = new ManagementClient(connectionString);
-
-            _receiveTimeout = _connectionString.Contains("OperationTimeout")
-                ? default(TimeSpan?)
-                : TimeSpan.FromSeconds(5);
         }
 
         /// <summary>
@@ -602,9 +597,7 @@ namespace Rebus.AzureServiceBus
             {
                 var messageReceiver = _messageReceiver;
 
-                var message = _receiveTimeout.HasValue
-                    ? await messageReceiver.ReceiveAsync(_receiveTimeout.Value).ConfigureAwait(false)
-                    : await messageReceiver.ReceiveAsync().ConfigureAwait(false);
+                var message = await messageReceiver.ReceiveAsync(ReceiveOperationTimeout).ConfigureAwait(false);
 
                 return message == null
                     ? null
@@ -711,6 +704,11 @@ namespace Rebus.AzureServiceBus
         /// Gets/sets the duplicate detection window
         /// </summary>
         public TimeSpan? DuplicateDetectionHistoryTimeWindow { get; set; }
+
+        /// <summary>
+        /// Gets/sets the receive timeout.
+        /// </summary>
+        public TimeSpan ReceiveOperationTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// Purges the input queue by receiving all messages as quickly as possible

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
@@ -95,6 +95,7 @@ namespace Rebus.Config
                     transport.LockDuration = settingsBuilder.LockDuration;
                     transport.AutoDeleteOnIdle = settingsBuilder.AutoDeleteOnIdle;
                     transport.DuplicateDetectionHistoryTimeWindow = settingsBuilder.DuplicateDetectionHistoryTimeWindow;
+                    transport.ReceiveOperationTimeout = settingsBuilder.ReceiveOperationTimeout;
                     
                     return transport;
                 });

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
@@ -19,6 +19,7 @@ namespace Rebus.Config
         internal TimeSpan? LockDuration { get; set; }
         internal TimeSpan? AutoDeleteOnIdle { get; set; }
         internal TimeSpan? DuplicateDetectionHistoryTimeWindow { get; set; }
+        internal TimeSpan ReceiveOperationTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// Enables partitioning whereby Azure Service Bus will be able to distribute messages between message stores and this way increase throughput.
@@ -145,6 +146,17 @@ namespace Rebus.Config
         public AzureServiceBusTransportSettings DoNotCheckQueueConfiguration()
         {
             DoNotCheckQueueConfigurationEnabled = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the receive operation timeout. This is basically the time the client waits for a message to appear in the queue.
+        /// This includes the time taken to establish a connection (either during the first receive or when connection needs to be re-established).
+        /// Defaults to 5 seconds.
+        /// </summary>
+        public AzureServiceBusTransportSettings SetReceiveOperationTimeout(TimeSpan receiveOperationTimeout)
+        {
+            ReceiveOperationTimeout = receiveOperationTimeout;
             return this;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/rebus-org/Rebus.AzureServiceBus/issues/33

I have removed the ReceiveAsync() w/o the timeout call. I don't see much value in supporting that.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
