### PR TITLE
Allow token-based authentication (Issue #50)

### DIFF
--- a/Rebus.AzureServiceBus.Tests/App.config
+++ b/Rebus.AzureServiceBus.Tests/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
+++ b/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
@@ -39,6 +39,10 @@
     <Compile Include="..\Rebus.AzureServiceBus\Internals\ManagementExtensions.cs" Link="Extensions\ManagementExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <ProjectReference Include="..\Rebus.AzureServiceBus\Rebus.AzureServiceBus.csproj" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.1" />
     <PackageReference Include="rebus" Version="6.0.0" />

--- a/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
+++ b/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
@@ -39,6 +39,8 @@
     <Compile Include="..\Rebus.AzureServiceBus\Internals\ManagementExtensions.cs" Link="Extensions\ManagementExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.8.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.0.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Rebus.AzureServiceBus.Tests/TokenProviderTest.cs
+++ b/Rebus.AzureServiceBus.Tests/TokenProviderTest.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.Azure.ServiceBus.Primitives;
+using Microsoft.Identity.Client;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Routing.TypeBased;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.AzureServiceBus.Tests
+{
+    [TestFixture]
+    public class TokenProviderTest : FixtureBase
+    {
+        const string QueueName = "token-provider-server";
+
+        BuiltinHandlerActivator _server;
+
+        protected override void SetUp()
+        {
+            _server = new BuiltinHandlerActivator();
+
+            Using(_server);
+
+            Configure.With(_server)
+                .Transport(t => t.UseAzureServiceBus(AsbTestConfig.ConnectionString, QueueName))
+                .Start();
+
+        }
+
+        [Test]
+        public async Task CanInitializeClientWithTokenProvider()
+        {
+            var gotTheString = new ManualResetEvent(false);
+
+            _server.Handle<string>(async _ => gotTheString.Set());
+
+            var configurer = Configure.With(new BuiltinHandlerActivator())
+                .Transport(t => t
+                    .UseAzureServiceBus("<insert connection string with endpoint only>", "<insert input queue>", CreateTokenProvider("<insert client ID>", "<insert client secret>", "<insert tenant ID>"))
+                    .DoNotCheckQueueConfiguration()
+                    .DoNotCreateQueues()
+                )
+                .Routing(r => r.TypeBased().Map<string>(QueueName));
+
+            using (var client = configurer.Start())
+            {
+                await client.Send("HEJ MED DIG MIN VEN");
+            }
+
+            gotTheString.WaitOrDie(TimeSpan.FromSeconds(5));
+        }
+
+        private ITokenProvider CreateTokenProvider(string clientId, string clientSecret, string tenantId)
+        {
+            return TokenProvider.CreateAzureActiveDirectoryTokenProvider(async (audience, authority, state) =>
+            {
+                IConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(clientId)
+                    .WithAuthority(authority)
+                    .WithClientSecret(clientSecret)
+                    .Build();
+
+                var serviceBusAudience = new Uri("https://servicebus.azure.net");
+
+                var authResult = await app.AcquireTokenForClient(new string[] { $"{serviceBusAudience}/.default" }).ExecuteAsync();
+                return authResult.AccessToken;
+
+            }, $"https://login.windows.net/{tenantId}");
+        }
+    }
+}

--- a/Rebus.AzureServiceBus.Tests/TokenProviderTest.cs
+++ b/Rebus.AzureServiceBus.Tests/TokenProviderTest.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 namespace Rebus.AzureServiceBus.Tests
 {
     [TestFixture]
+    [Ignore("Requires some manual setup")]
     public class TokenProviderTest : FixtureBase
     {
         const string QueueName = "token-provider-server";

--- a/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
@@ -82,7 +82,6 @@ namespace Rebus.AzureServiceBus
         /// <summary>
         /// Constructs the transport, connecting to the service bus pointed to by the connection string.
         /// </summary>
-        [CLSCompliant(false)]
         public AzureServiceBusTransport(string connectionString, string queueName, IRebusLoggerFactory rebusLoggerFactory, IAsyncTaskFactory asyncTaskFactory, INameFormatter nameFormatter, CancellationToken cancellationToken = default(CancellationToken), ITokenProvider tokenProvider = null)
         {
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Microsoft.Azure.ServiceBus.Primitives;
 using Rebus.AzureServiceBus;
 using Rebus.AzureServiceBus.NameFormat;
 using Rebus.Logging;
@@ -27,7 +28,7 @@ namespace Rebus.Config
         /// <summary>
         /// Configures Rebus to use Azure Service Bus to transport messages as a one-way client (i.e. will not be able to receive any messages)
         /// </summary>
-        public static AzureServiceBusTransportClientSettings UseAzureServiceBusAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionString)
+        public static AzureServiceBusTransportClientSettings UseAzureServiceBusAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionString, ITokenProvider tokenProvider = null)
         {
             var settingsBuilder = new AzureServiceBusTransportClientSettings();
 
@@ -53,7 +54,8 @@ namespace Rebus.Config
                         rebusLoggerFactory: rebusLoggerFactory,
                         asyncTaskFactory: asyncTaskFactory,
                         nameFormatter: nameFormatter,
-                        cancellationToken: cancellationToken
+                        cancellationToken: cancellationToken,
+                        tokenProvider: tokenProvider
                     );
                 });
 
@@ -68,7 +70,7 @@ namespace Rebus.Config
         /// Configures Rebus to use Azure Service Bus queues to transport messages, connecting to the service bus instance pointed to by the connection string
         /// (or the connection string with the specified name from the current app.config)
         /// </summary>
-        public static AzureServiceBusTransportSettings UseAzureServiceBus(this StandardConfigurer<ITransport> configurer, string connectionString, string inputQueueAddress)
+        public static AzureServiceBusTransportSettings UseAzureServiceBus(this StandardConfigurer<ITransport> configurer, string connectionString, string inputQueueAddress, ITokenProvider tokenProvider = null)
         {
             var settingsBuilder = new AzureServiceBusTransportSettings();
 
@@ -88,7 +90,8 @@ namespace Rebus.Config
                         rebusLoggerFactory: rebusLoggerFactory,
                         asyncTaskFactory: asyncTaskFactory,
                         nameFormatter: nameFormatter,
-                        cancellationToken: cancellationToken
+                        cancellationToken: cancellationToken,
+                        tokenProvider: tokenProvider
                     );
 
                     if (settingsBuilder.PrefetchingEnabled)

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Azure.ServiceBus.Primitives;
+using System;
 // ReSharper disable UnusedMember.Global
 
 namespace Rebus.Config

--- a/Rebus.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Rebus.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d01643a8-22fc-45f4-9cb3-51a8c2d8bcc3")]


### PR DESCRIPTION
This change lets a consumer pass an `ITokenProvider` to Rebus. The token provider is then passed to the underlying Azure Service Bus clients.

Token providers support authentication methods beyond SAS. For example, they support Azure Active Directory, which can be used for Role-Based Access Control (RBAC). This gives the consumer more granular access control over queues and topics.

I implemented this as an optional parameter in `UseAzureServiceBus`. The argument (default null) is passed to the transport constructor. If the argument is null, the various Service Bus clients are instantiated with the same constructor overloads that were in the code before my changes. If the parameter is not null, alternative constructor overloads, which accept `ITokenProvider`s, are called instead.

I added a passing test in `TokenProviderTest`, but it only covers queues.

Let me know if any questions, suggestions, etc....

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
