### PR TITLE
Migrate to Azure.Messaging.ServiceBus

### DIFF
--- a/Rebus.AzureServiceBus.Tests/AzureServiceBusDoNotCreateQueue.cs
+++ b/Rebus.AzureServiceBus.Tests/AzureServiceBusDoNotCreateQueue.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.AzureServiceBus.NameFormat;

--- a/Rebus.AzureServiceBus.Tests/Bugs/FastSubscriber.cs
+++ b/Rebus.AzureServiceBus.Tests/Bugs/FastSubscriber.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus.Administration;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Config;
@@ -49,20 +49,13 @@ namespace Rebus.AzureServiceBus.Tests.Bugs
         [Ignore("run manually")]
         public async Task DeleteAllTopics()
         {
-            var managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
+            var managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
 
-            while (true)
+            await foreach (var topic in managementClient.GetTopicsAsync())
             {
-                var topics = await managementClient.GetTopicsAsync();
-
-                if (!topics.Any()) break;
-
-                foreach (var topic in topics)
-                {
-                    Console.Write($"Deleting '{topic.Path}'... ");
-                    await managementClient.DeleteTopicAsync(topic.Path);
-                    Console.WriteLine("OK");
-                }
+                Console.Write($"Deleting '{topic.Name}'... ");
+                await managementClient.DeleteTopicAsync(topic.Name);
+                Console.WriteLine("OK");
             }
         }
     }

--- a/Rebus.AzureServiceBus.Tests/Bugs/QueueDeleter.cs
+++ b/Rebus.AzureServiceBus.Tests/Bugs/QueueDeleter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Rebus.Internals;
 
 namespace Rebus.AzureServiceBus.Tests.Bugs
@@ -16,7 +16,7 @@ namespace Rebus.AzureServiceBus.Tests.Bugs
 
         public void Dispose()
         {
-            var managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
+            var managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
 
             AsyncHelpers.RunSync(async () =>
             {
@@ -24,11 +24,11 @@ namespace Rebus.AzureServiceBus.Tests.Bugs
                 {
                     var topicDescription = await managementClient.GetQueueAsync(_queueName);
 
-                    await managementClient.DeleteQueueAsync(topicDescription.Path);
+                    await managementClient.DeleteQueueAsync(topicDescription.Value.Name);
 
                     Console.WriteLine($"Deleted queue '{_queueName}'");
                 }
-                catch (MessagingEntityNotFoundException)
+                catch (ServiceBusException)
                 {
                     // it's ok
                 }

--- a/Rebus.AzureServiceBus.Tests/Bugs/TopicDeleter.cs
+++ b/Rebus.AzureServiceBus.Tests/Bugs/TopicDeleter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Rebus.Internals;
 
 namespace Rebus.AzureServiceBus.Tests.Bugs
@@ -16,7 +16,7 @@ namespace Rebus.AzureServiceBus.Tests.Bugs
 
         public void Dispose()
         {
-            var managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
+            var managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
 
             AsyncHelpers.RunSync(async () =>
             {
@@ -24,11 +24,11 @@ namespace Rebus.AzureServiceBus.Tests.Bugs
                 {
                     var topicDescription = await managementClient.GetTopicAsync(_topicName);
 
-                    await managementClient.DeleteTopicAsync(topicDescription.Path);
+                    await managementClient.DeleteTopicAsync(topicDescription.Value.Name);
 
                     Console.WriteLine($"Deleted topic '{_topicName}'");
                 }
-                catch (MessagingEntityNotFoundException)
+                catch (ServiceBusException)
                 {
                     // it's ok
                 }

--- a/Rebus.AzureServiceBus.Tests/Bugs/VerifyTopicsAreCreatedAsNeeded.cs
+++ b/Rebus.AzureServiceBus.Tests/Bugs/VerifyTopicsAreCreatedAsNeeded.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus.Administration;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Config;
@@ -74,19 +74,12 @@ namespace Rebus.AzureServiceBus.Tests.Bugs
 
         static async Task DeleteAllTopics()
         {
-            var managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
+            var managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
 
-            while (true)
+            await foreach (var topic in managementClient.GetTopicsAsync())
             {
-                var topics = await managementClient.GetTopicsAsync();
-
-                if (!topics.Any()) return;
-
-                await Task.WhenAll(topics.Select(async topic =>
-                {
-                    Console.WriteLine($"Deleting topic '{topic.Path}'");
-                    await managementClient.DeleteTopicAsync(topic.Path);
-                }));
+                Console.WriteLine($"Deleting topic '{topic.Name}'");
+                await managementClient.DeleteTopicAsync(topic.Name);
             }
         }
     }

--- a/Rebus.AzureServiceBus.Tests/Bugs/VerifyTopicsCanHaveSlashesInThem.cs
+++ b/Rebus.AzureServiceBus.Tests/Bugs/VerifyTopicsCanHaveSlashesInThem.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus.Administration;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Config;
@@ -49,10 +49,10 @@ namespace Rebus.AzureServiceBus.Tests.Bugs
 
             // make a final verification: the topic has a / in it
 
-            var managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
+            var managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
             var topicDescription = await managementClient.GetTopicAsync(topicNameWithSlash);
 
-            Assert.That(topicDescription.Path, Contains.Substring(topicNameWithSlash));
+            Assert.That(topicDescription.Value.Name, Contains.Substring(topicNameWithSlash));
         }
     }
 }

--- a/Rebus.AzureServiceBus.Tests/CanChangeDefaultLockDuration.cs
+++ b/Rebus.AzureServiceBus.Tests/CanChangeDefaultLockDuration.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus.Administration;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.AzureServiceBus.Tests.Factories;
@@ -13,12 +13,12 @@ namespace Rebus.AzureServiceBus.Tests
     [TestFixture]
     public class CanChangeDefaultLockDuration : FixtureBase
     {
-        ManagementClient _managementClient;
+        ServiceBusAdministrationClient _managementClient;
         string _queueName;
 
         protected override void SetUp()
         {
-            _managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
+            _managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
             _queueName = TestConfig.GetName("lockduration");
 
             AsyncHelpers.RunSync(() => _managementClient.DeleteQueueIfExistsAsync(_queueName));
@@ -46,8 +46,8 @@ namespace Rebus.AzureServiceBus.Tests
 
             var queueDescription = await _managementClient.GetQueueAsync(_queueName);
 
-            Assert.That(queueDescription.RequiresDuplicateDetection, Is.True);
-            Assert.That(queueDescription.DuplicateDetectionHistoryTimeWindow, Is.EqualTo(duration));
+            Assert.That(queueDescription.Value.RequiresDuplicateDetection, Is.True);
+            Assert.That(queueDescription.Value.DuplicateDetectionHistoryTimeWindow, Is.EqualTo(duration));
         }
 
         [Test]
@@ -90,9 +90,9 @@ namespace Rebus.AzureServiceBus.Tests
 
             var queueDescription = await _managementClient.GetQueueAsync(_queueName);
 
-            Assert.That(queueDescription.DefaultMessageTimeToLive, Is.EqualTo(TimeSpan.FromDays(1)));
-            Assert.That(queueDescription.LockDuration, Is.EqualTo(TimeSpan.FromMinutes(1)));
-            Assert.That(queueDescription.AutoDeleteOnIdle, Is.EqualTo(TimeSpan.FromHours(5)));
+            Assert.That(queueDescription.Value.DefaultMessageTimeToLive, Is.EqualTo(TimeSpan.FromDays(1)));
+            Assert.That(queueDescription.Value.LockDuration, Is.EqualTo(TimeSpan.FromMinutes(1)));
+            Assert.That(queueDescription.Value.AutoDeleteOnIdle, Is.EqualTo(TimeSpan.FromHours(5)));
         }
     }
 }

--- a/Rebus.AzureServiceBus.Tests/ConnectionStringParser.cs
+++ b/Rebus.AzureServiceBus.Tests/ConnectionStringParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Azure.Messaging.ServiceBus;
 using Rebus.Extensions;
 
 namespace Rebus.AzureServiceBus
@@ -44,10 +45,11 @@ namespace Rebus.AzureServiceBus
                 .ToDictionary(a => a.key, a => a.value);
         }
 
-        public string Endpoint => _parts.GetValue("Endpoint");
+        public string Endpoint => _parts.GetValue("Endpoint").TrimEnd('/');
         public string SharedAccessKeyName => _parts.GetValue("SharedAccessKeyName");
         public string SharedAccessKey => _parts.GetValue("SharedAccessKey");
         public string EntityPath => _parts.GetValueOrNull("EntityPath");
+        public ServiceBusTransportType Transport => (ServiceBusTransportType)Enum.Parse(typeof(ServiceBusTransportType), _parts.GetValueOrNull("Transport") ?? nameof(ServiceBusTransportType.AmqpTcp));
 
         public override string ToString()
         {

--- a/Rebus.AzureServiceBus.Tests/Factories/AzureServiceBusBusFactory.cs
+++ b/Rebus.AzureServiceBus.Tests/Factories/AzureServiceBusBusFactory.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus;
 using Rebus.Activation;
 using Rebus.AzureServiceBus.NameFormat;
 using Rebus.AzureServiceBus.Tests.Extensions;

--- a/Rebus.AzureServiceBus.Tests/Factories/AzureServiceBusTransportFactory.cs
+++ b/Rebus.AzureServiceBus.Tests/Factories/AzureServiceBusTransportFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Rebus.AzureServiceBus.NameFormat;
 using Rebus.Extensions;
 using Rebus.Internals;
@@ -64,7 +64,7 @@ namespace Rebus.AzureServiceBus.Tests.Factories
         {
             AsyncHelpers.RunSync(async () =>
             {
-                var managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
+                var managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
 
                 try
                 {
@@ -72,7 +72,7 @@ namespace Rebus.AzureServiceBus.Tests.Factories
                     await managementClient.DeleteQueueAsync(queueName);
                     Console.WriteLine("OK!");
                 }
-                catch (MessagingEntityNotFoundException)
+                catch (ServiceBusException)
                 {
                     Console.WriteLine("OK (was not there)");
                 }
@@ -83,7 +83,7 @@ namespace Rebus.AzureServiceBus.Tests.Factories
         {
             AsyncHelpers.RunSync(async () =>
             {
-                var managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
+                var managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
 
                 try
                 {
@@ -91,7 +91,7 @@ namespace Rebus.AzureServiceBus.Tests.Factories
                     await managementClient.DeleteTopicAsync(topic);
                     Console.WriteLine("OK!");
                 }
-                catch (MessagingEntityNotFoundException)
+                catch (ServiceBusException)
                 {
                     Console.WriteLine("OK! (wasn't even there)");
                 }

--- a/Rebus.AzureServiceBus.Tests/FailsWhenSendingToNonExistentQueue.cs
+++ b/Rebus.AzureServiceBus.Tests/FailsWhenSendingToNonExistentQueue.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-using Microsoft.Azure.ServiceBus;
+using Azure.Messaging.ServiceBus;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.AzureServiceBus.Tests.Factories;
@@ -34,7 +34,7 @@ namespace Rebus.AzureServiceBus.Tests
 
             Console.WriteLine(exception);
 
-            var notFoundException = (MessagingEntityNotFoundException) exception.InnerException;
+            var notFoundException = (ServiceBusException) exception.InnerException;
 
             Console.WriteLine(notFoundException);
 

--- a/Rebus.AzureServiceBus.Tests/NotCreatingQueueTest.cs
+++ b/Rebus.AzureServiceBus.Tests/NotCreatingQueueTest.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus.Administration;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Config;
@@ -16,7 +16,7 @@ namespace Rebus.AzureServiceBus.Tests
         public async Task ShouldNotCreateInputQueueWhenConfiguredNotTo()
         {
             var connectionString = AsbTestConfig.ConnectionString;
-            var managementClient = new ManagementClient(connectionString);
+            var managementClient = new ServiceBusAdministrationClient(connectionString);
             
             var queueName = Guid.NewGuid().ToString("N");
 

--- a/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
+++ b/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
@@ -43,14 +43,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <ProjectReference Include="..\Rebus.AzureServiceBus\Rebus.AzureServiceBus.csproj" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.2" />
     <PackageReference Include="rebus" Version="6.4.1" />
     <PackageReference Include="rebus.tests.contracts" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="asb_connection_string.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="asb_connection_string.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Rebus.AzureServiceBus.Tests/TestAsbNaming.cs
+++ b/Rebus.AzureServiceBus.Tests/TestAsbNaming.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Management;
+using Azure.Messaging.ServiceBus.Administration;
 using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.AzureServiceBus.NameFormat;
@@ -17,13 +16,13 @@ namespace Rebus.AzureServiceBus.Tests
     [TestFixture]
     public class TestAsbNaming : FixtureBase
     {
-        ManagementClient _managementClient;
+        ServiceBusAdministrationClient _managementClient;
         string _endpoint;
 
         protected override void SetUp()
         {
-            _managementClient = new ManagementClient(AsbTestConfig.ConnectionString);
-            _endpoint = new ServiceBusConnectionStringBuilder(AsbTestConfig.ConnectionString).Endpoint;
+            _managementClient = new ServiceBusAdministrationClient(AsbTestConfig.ConnectionString);
+            _endpoint = new ConnectionStringParser(AsbTestConfig.ConnectionString).Endpoint;
         }
 
         [Test]
@@ -51,7 +50,7 @@ namespace Rebus.AzureServiceBus.Tests
             Assert.IsTrue(await _managementClient.QueueExistsAsync("group/some.inputqueue"));
             Assert.IsTrue(await _managementClient.TopicExistsAsync("group/some.interesting_topic"));
             var subscription = await _managementClient.GetSubscriptionAsync("group/some.interesting_topic", "group_some.inputqueue");
-            Assert.AreEqual(_endpoint + "/group/some.inputqueue", subscription.ForwardTo);
+            Assert.AreEqual(_endpoint + "/group/some.inputqueue", subscription.Value.ForwardTo);
         }
 
         [Test]
@@ -79,7 +78,7 @@ namespace Rebus.AzureServiceBus.Tests
             Assert.IsTrue(await _managementClient.QueueExistsAsync("group/some.inputqueue"));
             Assert.IsTrue(await _managementClient.TopicExistsAsync("system.private.corelib/system.object"));
             var subscription = await _managementClient.GetSubscriptionAsync("system.private.corelib/system.object", "group_some.inputqueue");
-            Assert.AreEqual(_endpoint + "/group/some.inputqueue", subscription.ForwardTo);
+            Assert.AreEqual(_endpoint + "/group/some.inputqueue", subscription.Value.ForwardTo);
         }
 
         [Test]
@@ -109,7 +108,7 @@ namespace Rebus.AzureServiceBus.Tests
             Assert.IsTrue(await _managementClient.QueueExistsAsync("group/some_inputqueue"));
             Assert.IsTrue(await _managementClient.TopicExistsAsync("group/some_interesting_topic"));
             var subscription = await _managementClient.GetSubscriptionAsync("group/some_interesting_topic", "some_inputqueue");
-            Assert.AreEqual(_endpoint + "/group/some_inputqueue", subscription.ForwardTo);
+            Assert.AreEqual(_endpoint + "/group/some_inputqueue", subscription.Value.ForwardTo);
         }
 
         [Test]
@@ -139,7 +138,7 @@ namespace Rebus.AzureServiceBus.Tests
             Assert.IsTrue(await _managementClient.QueueExistsAsync("group/some_inputqueue"));
             Assert.IsTrue(await _managementClient.TopicExistsAsync("system_object__mscorlib"));
             var subscription = await _managementClient.GetSubscriptionAsync("system_object__mscorlib", "some_inputqueue");
-            Assert.AreEqual(_endpoint + "/group/some_inputqueue", subscription.ForwardTo);
+            Assert.AreEqual(_endpoint + "/group/some_inputqueue", subscription.Value.ForwardTo);
         }
 
         [Test]
@@ -171,7 +170,7 @@ namespace Rebus.AzureServiceBus.Tests
             Assert.IsTrue(await _managementClient.QueueExistsAsync("group/some.inputqueue"));
             Assert.IsTrue(await _managementClient.TopicExistsAsync("group/some_interesting_topic"));
             var subscription = await _managementClient.GetSubscriptionAsync("group/some_interesting_topic", "some_inputqueue");
-            Assert.AreEqual(_endpoint + "/group/some.inputqueue", subscription.ForwardTo);
+            Assert.AreEqual(_endpoint + "/group/some.inputqueue", subscription.Value.ForwardTo);
         }
 
         [Test]
@@ -200,7 +199,7 @@ namespace Rebus.AzureServiceBus.Tests
             Assert.IsTrue(await _managementClient.QueueExistsAsync("prefix/group/some.inputqueue"));
             Assert.IsTrue(await _managementClient.TopicExistsAsync("prefix/group/some_interesting_topic"));
             var subscription = await _managementClient.GetSubscriptionAsync("prefix/group/some_interesting_topic", "some_inputqueue");
-            Assert.AreEqual(_endpoint + "/prefix/group/some.inputqueue", subscription.ForwardTo);
+            Assert.AreEqual(_endpoint + "/prefix/group/some.inputqueue", subscription.Value.ForwardTo);
         }
     }
 }

--- a/Rebus.AzureServiceBus.Tests/TestUtilities/StubTokenCredential.cs
+++ b/Rebus.AzureServiceBus.Tests/TestUtilities/StubTokenCredential.cs
@@ -1,0 +1,45 @@
+﻿using Azure.Core;
+using Microsoft.Identity.Client;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rebus.AzureServiceBus.Tests
+{
+    internal class StubTokenCredential : TokenCredential
+    {
+        private readonly string clientId;
+        private readonly string clientSecret;
+        private readonly string tenantId;
+
+        public StubTokenCredential(string clientId, string clientSecret, string tenantId)
+        {
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+            this.tenantId = tenantId;
+        }
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            AccessToken token = default;
+            
+            Task.Run(async () => token = await this.GetTokenAsync(requestContext, cancellationToken)).Wait();
+
+            return token;
+        }
+
+        public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            IConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(clientId)
+                .WithAuthority($"https://login.windows.net/{tenantId}")
+                .WithClientSecret(clientSecret)
+                .Build();
+
+            var serviceBusAudience = new Uri("https://servicebus.azure.net");
+
+            var authResult = await app.AcquireTokenForClient(new string[] { $"{serviceBusAudience}/.default" }).ExecuteAsync(cancellationToken);
+
+            return new AccessToken(authResult.AccessToken, authResult.ExpiresOn);
+        }
+    }
+}

--- a/Rebus.AzureServiceBus.Tests/TokenProviderTest.cs
+++ b/Rebus.AzureServiceBus.Tests/TokenProviderTest.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Azure.ServiceBus.Primitives;
-using Microsoft.Identity.Client;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Config;
 using Rebus.Routing.TypeBased;
@@ -42,7 +40,7 @@ namespace Rebus.AzureServiceBus.Tests
 
             var configurer = Configure.With(new BuiltinHandlerActivator())
                 .Transport(t => t
-                    .UseAzureServiceBus("<insert connection string with endpoint only>", "<insert input queue>", CreateTokenProvider("<insert client ID>", "<insert client secret>", "<insert tenant ID>"))
+                    .UseAzureServiceBus("<insert connection string with endpoint only>", "<insert input queue>", new StubTokenCredential("<insert client ID>", "<insert client secret>", "<insert tenant ID>"))
                     .DoNotCheckQueueConfiguration()
                     .DoNotCreateQueues()
                 )
@@ -54,23 +52,6 @@ namespace Rebus.AzureServiceBus.Tests
             }
 
             gotTheString.WaitOrDie(TimeSpan.FromSeconds(5));
-        }
-
-        private ITokenProvider CreateTokenProvider(string clientId, string clientSecret, string tenantId)
-        {
-            return TokenProvider.CreateAzureActiveDirectoryTokenProvider(async (audience, authority, state) =>
-            {
-                IConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(clientId)
-                    .WithAuthority(authority)
-                    .WithClientSecret(clientSecret)
-                    .Build();
-
-                var serviceBusAudience = new Uri("https://servicebus.azure.net");
-
-                var authResult = await app.AcquireTokenForClient(new string[] { $"{serviceBusAudience}/.default" }).ExecuteAsync();
-                return authResult.AccessToken;
-
-            }, $"https://login.windows.net/{tenantId}");
         }
     }
 }

--- a/Rebus.AzureServiceBus/AzureServiceBus/ConnectionStringParser.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBus/ConnectionStringParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Azure.Messaging.ServiceBus;
 using Rebus.Extensions;
 
 namespace Rebus.AzureServiceBus
@@ -33,10 +34,11 @@ namespace Rebus.AzureServiceBus
                 .ToDictionary(a => a.key, a => a.value);
         }
 
-        public string Endpoint => _parts.GetValue("Endpoint");
+        public string Endpoint => _parts.GetValue("Endpoint").TrimEnd('/');
         public string SharedAccessKeyName => _parts.GetValue("SharedAccessKeyName");
         public string SharedAccessKey => _parts.GetValue("SharedAccessKey");
         public string EntityPath => _parts.GetValueOrNull("EntityPath");
+        public ServiceBusTransportType Transport => (ServiceBusTransportType)Enum.Parse(typeof(ServiceBusTransportType), _parts.GetValueOrNull("Transport") ?? nameof(ServiceBusTransportType.AmqpTcp));
 
         public override string ToString()
         {

--- a/Rebus.AzureServiceBus/AzureServiceBus/ReceivedMessage.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBus/ReceivedMessage.cs
@@ -1,14 +1,13 @@
-﻿using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Core;
+﻿using Azure.Messaging.ServiceBus;
 
 namespace Rebus.AzureServiceBus
 {
     class ReceivedMessage
     {
-        public Message Message { get; }
-        public MessageReceiver MessageReceiver { get; }
+        public ServiceBusReceivedMessage Message { get; }
+        public ServiceBusReceiver MessageReceiver { get; }
 
-        public ReceivedMessage(Message message, MessageReceiver messageReceiver)
+        public ReceivedMessage(ServiceBusReceivedMessage message, ServiceBusReceiver messageReceiver)
         {
             Message = message;
             MessageReceiver = messageReceiver;

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Azure.ServiceBus.Primitives;
-using System;
+﻿using System;
 // ReSharper disable UnusedMember.Global
 
 namespace Rebus.Config

--- a/Rebus.AzureServiceBus/Internals/MessageExtensions.cs
+++ b/Rebus.AzureServiceBus/Internals/MessageExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Azure.ServiceBus;
+using Azure.Messaging.ServiceBus;
 
 namespace Rebus.Internals
 {
@@ -12,14 +12,13 @@ namespace Rebus.Internals
         /// There's no way to get the actual size, because ASB puts all kinds of crap in the message too.
         /// We do our best here, and then we put in a little bit of headspace
         /// </summary>
-        public static long EstimateSize(this Message message)
+        public static long EstimateSize(this ServiceBusMessage message)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
 
-            long GetSize(KeyValuePair<string, object> kvp) => Encoding.UTF8.GetByteCount(kvp.Key) +
-                                                              Encoding.UTF8.GetByteCount(kvp.Value?.ToString() ?? "");
-
-            return 2 * (message.Size + message.UserProperties.Sum(GetSize));
+            return 2 * (message.Body.ToMemory().Length + message.ApplicationProperties.Sum(GetSize));
         }
+
+        private static long GetSize(KeyValuePair<string, object> kvp) => Encoding.UTF8.GetByteCount(kvp.Key) + Encoding.UTF8.GetByteCount(kvp.Value?.ToString() ?? "");
     }
 }

--- a/Rebus.AzureServiceBus/Internals/MessageLockRenewer.cs
+++ b/Rebus.AzureServiceBus/Internals/MessageLockRenewer.cs
@@ -1,18 +1,17 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Core;
+using Azure.Messaging.ServiceBus;
 
 namespace Rebus.Internals
 {
     class MessageLockRenewer
     {
-        readonly Message _message;
-        readonly MessageReceiver _messageReceiver;
+        readonly ServiceBusReceivedMessage _message;
+        readonly ServiceBusReceiver _messageReceiver;
 
         DateTime _nextRenewal;
 
-        public MessageLockRenewer(Message message, MessageReceiver messageReceiver)
+        public MessageLockRenewer(ServiceBusReceivedMessage message, ServiceBusReceiver messageReceiver)
         {
             _message = message;
             _messageReceiver = messageReceiver;
@@ -28,7 +27,7 @@ namespace Rebus.Internals
         {
             try
             {
-                await _messageReceiver.RenewLockAsync(_message);
+                await _messageReceiver.RenewMessageLockAsync(_message);
 
                 SetNextRenewal();
             }
@@ -40,11 +39,11 @@ namespace Rebus.Internals
         {
             var now = DateTime.UtcNow;
 
-            var remainingTime = LockedUntilUtc - now;
+            var remainingTime = LockedUntil - now;
             var halfOfRemainingTime = TimeSpan.FromMinutes(0.5 * remainingTime.TotalMinutes);
             _nextRenewal = now + halfOfRemainingTime;
         }
 
-        DateTime LockedUntilUtc => _message.SystemProperties.LockedUntilUtc;
+        DateTimeOffset LockedUntil => _message.LockedUntil;
     }
 }

--- a/Rebus.AzureServiceBus/Rebus.AzureServiceBus.csproj
+++ b/Rebus.AzureServiceBus/Rebus.AzureServiceBus.csproj
@@ -39,7 +39,7 @@
     <DocumentationFile>bin\Release\Rebus.AzureServiceBus.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.2" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.1.2" />
     <PackageReference Include="Rebus" Version="[6, 7)" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi @mookid8000,
referred to #69. I have initialize the porting to Azure.Messaging.ServiceBus.

Though the packages share the operating principles, there are many classes that have been renamed and this has caused many changes.

I have been fix the major part of broken tests but I has not be able to fix [VerifyHowThingsWorkWhenConnectionStringEndpointHasPath.ItWorks](https://github.com/rebus-org/Rebus.AzureServiceBus/blob/2148577611e257039f507c66b8cb66fe5c0d0078/Rebus.AzureServiceBus.Tests/Bugs/VerifyHowThingsWorkWhenConnectionStringEndpointHasPath.cs#L14) and I don't have run the manual tests.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
