### PR TITLE
Ensure logging when dead lettering

### DIFF
--- a/Rebus.AzureServiceBus/Config/AdditionalAzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AdditionalAzureServiceBusConfigurationExtensions.cs
@@ -53,7 +53,7 @@ namespace Rebus.Config
                         messageId = "<unknown>";
                     }
 
-                    _log.Error(exception, "Dead-lettering message with ID {messageId}", messageId);
+                    _log.Error(exception, "Dead-lettering message with ID {messageId}, reason={deadLetterReason}", messageId, deadLetterReason);
                     await messageReceiver.DeadLetterMessageAsync(message, deadLetterReason, deadLetterErrorDescription);
 
                     // remove the message from the context, so the transport doesn't try to complete the message


### PR DESCRIPTION
When not using dead lettering, logging is made by the PoisonQueueErrorHandler, but when using dead lettering, this is short circuited and only warnings are logged.

This PR makes sure that messages that are dead lettered also are error logged.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
