### PR TITLE
Support for Session-aware entities

### DIFF
--- a/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
@@ -47,6 +47,8 @@ public class AzureServiceBusTransport : ITransport, IInitializable, IDisposable,
     /// </summary>
     public const string MagicDeferredMessagesAddress = "___deferred___";
 
+    const string SessionIdHeader = "SessionId";
+
     static readonly ServiceBusRetryOptions DefaultRetryStrategy = new()
     {
         Mode = ServiceBusRetryMode.Exponential,
@@ -524,6 +526,11 @@ public class AzureServiceBusTransport : ITransport, IInitializable, IDisposable,
         if (headers.TryGetValue(Headers.MessageId, out var messageId))
         {
             message.MessageId = messageId;
+        }
+        
+        if (headers.TryGetValue(SessionIdHeader, out var sessionId))
+        {
+            message.SessionId = sessionId;
         }
 
         message.Subject = transportMessage.GetMessageLabel();

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
@@ -105,6 +105,7 @@ public static class AzureServiceBusConfigurationExtensions
 
                 transport.AutomaticallyRenewPeekLock = settingsBuilder.AutomaticPeekLockRenewalEnabled;
                 transport.PartitioningEnabled = settingsBuilder.PartitioningEnabled;
+                transport.RequiresSession = settingsBuilder.SessionsEnabled;
                 transport.DoNotCreateQueuesEnabled = settingsBuilder.DoNotCreateQueuesEnabled;
                 transport.DefaultMessageTimeToLive = settingsBuilder.DefaultMessageTimeToLive;
                 transport.DoNotCheckQueueConfigurationEnabled = settingsBuilder.DoNotCheckQueueConfigurationEnabled;

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
@@ -11,6 +11,7 @@ public class AzureServiceBusTransportSettings
     internal bool PrefetchingEnabled { get; set; }
     internal int NumberOfMessagesToPrefetch { get; set; }
     internal bool PartitioningEnabled { get; set; }
+    internal bool SessionsEnabled { get; set; }
     internal bool DoNotCreateQueuesEnabled { get; set; }
     internal bool AutomaticPeekLockRenewalEnabled { get; set; }
     internal bool DoNotCheckQueueConfigurationEnabled { get; set; }
@@ -30,6 +31,16 @@ public class AzureServiceBusTransportSettings
     public AzureServiceBusTransportSettings EnablePartitioning()
     {
         PartitioningEnabled = true;
+        return this;
+    }
+    
+    /// <summary>
+    /// Enables sessions whereby messages will be processed in order based on their SessionId header.
+    /// Sessions cannot be enabled after a queue is created, so it must be enabled before Rebus creates the input queue.
+    /// </summary>
+    public AzureServiceBusTransportSettings EnableSessions()
+    {
+        SessionsEnabled = true;
         return this;
     }
 


### PR DESCRIPTION
This pull request sets the `SessionId` property on the `ServiceBusMessage` based on a `SessionId` header.

This is useful for FIFO scenarios (similar to Aws SQS) as described here: https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
