### PR TITLE
WIP refactor(transport): separate management from transport

### DIFF
--- a/Rebus.AzureServiceBus.Tests/NotCreatingSubscriberTest.cs
+++ b/Rebus.AzureServiceBus.Tests/NotCreatingSubscriberTest.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Identity;
+using Azure.Messaging.ServiceBus.Administration;
+using Azure.ResourceManager;
+using Azure.ResourceManager.ServiceBus;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.AzureServiceBus.Tests.Bugs;
+using Rebus.Config;
+using Rebus.Tests.Contracts;
+
+namespace Rebus.AzureServiceBus.Tests;
+
+[TestFixture]
+public class NotCreatingSubscriberTest : FixtureBase
+{
+    [Test]
+    public async Task ShouldNotRegisterSubscriberWhenConfiguredNotTo()
+    {
+        var connectionString = AsbTestConfig.ConnectionString;
+        var managementClient = new ServiceBusAdministrationClient(connectionString);
+
+        var topic = Guid.NewGuid().ToString("N");
+        var queue = Guid.NewGuid().ToString("N");
+
+        await managementClient.CreateTopicAsync(topic);
+        Using(new TopicDeleter(topic));
+        
+        await managementClient.CreateQueueAsync(queue);
+        Using(new QueueDeleter(queue));
+        
+        var arm = new ArmClient(new DefaultAzureCredential());
+        var azure = await arm.GetSubscriptions().GetAsync("9391c94a-1a42-4f34-a835-ce73e4661f34");
+        var rg = await azure.Value.GetResourceGroupAsync("rg-servicebus");
+        var sb = await rg.Value.GetServiceBusNamespaceAsync("sbmanuel");
+        var t = await sb.Value.GetServiceBusTopicAsync(topic);
+         await t.Value.GetServiceBusSubscriptions()
+            .CreateOrUpdateAsync(WaitUntil.Completed, queue, new ServiceBusSubscriptionData
+        {
+            ForwardTo = queue
+        });
+
+        var before = await managementClient.GetSubscriptionAsync(topic, queue);
+        
+        var bus = Configure.With(Using(new BuiltinHandlerActivator()))
+            .Logging(l => l.ColoredConsole())
+            .Transport(t => t
+                .UseAzureServiceBus(connectionString, queue)
+                .DoNotCreateQueues()
+                .DoNotCheckQueueConfiguration())
+            .Start();
+
+        await bus.Advanced.Topics.Subscribe(topic);
+        var after = await managementClient.GetSubscriptionAsync(topic, queue);
+        Assert.AreEqual(before.Value.ForwardTo, after.Value.ForwardTo);
+    }
+}

--- a/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
+++ b/Rebus.AzureServiceBus.Tests/Rebus.AzureServiceBus.Tests.csproj
@@ -5,6 +5,7 @@
 		<LangVersion>10</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Azure.ResourceManager.ServiceBus" Version="1.0.0" />
 		<PackageReference Include="Hypothesist.Rebus" Version="2.1.44" />
 		<PackageReference Include="microsoft.net.test.sdk" Version="17.4.1" />
 		<PackageReference Include="nunit" Version="3.13.3" />


### PR DESCRIPTION
First attempt to separate the infrastructure logic from the transport.

Would've been nice when `ITransport` itself was segregated into at least 2 interfaces. Also, the `IInitialize` doesn't seem to be invoked automatically for anything other than the transport.

Maybe you can validate if this split makes sense. There's still the `GetActualAddress` where I didn't really have a good idea where it belongs. It would remove the `NameFormatter` dependency from the `Transport` but not sure that it's better and have an additional dependency on the infra/management.


---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
