### PR TITLE
feat: Add DoNotConfigureTopic option to Azure Service Bus transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ _ReSharper.*
 *.suo
 *.cache
 ~$*
+.idea/*
 .vs
 .vs/*
 _NCrunch_*

--- a/Rebus.AzureServiceBus.Tests/AzureServiceBusConfigurationExtensionsDoNotConfigureTopicTest.cs
+++ b/Rebus.AzureServiceBus.Tests/AzureServiceBusConfigurationExtensionsDoNotConfigureTopicTest.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.AzureServiceBus.NameFormat;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Tests.Contracts;
+using Rebus.Threading.TaskParallelLibrary;
+
+namespace Rebus.AzureServiceBus.Tests
+{
+    [TestFixture]
+    public class AzureServiceBusConfigurationExtensionsDoNotConfigureTopicTest : FixtureBase
+    {
+        static readonly string TestQueueName = TestConfig.GetName("test-queue");
+        readonly ConsoleLoggerFactory _consoleLoggerFactory = new ConsoleLoggerFactory(false);
+        
+        [Test]
+        public void UseAzureServiceBus_WithDoNotConfigureTopic_SetsDoNotConfigureTopicEnabledToTrue()
+        {
+            var transport = new AzureServiceBusTransport(
+                AsbTestConfig.ConnectionString, 
+                TestQueueName, 
+                _consoleLoggerFactory, 
+                new TplAsyncTaskFactory(_consoleLoggerFactory), 
+                new DefaultNameFormatter(), 
+                new AzureServiceBus.Messages.DefaultMessageConverter());
+            
+            Using(transport);
+            
+            transport.Initialize();
+            
+            var settings = new AzureServiceBusTransportSettings();
+            settings.DoNotConfigureTopic();
+            
+            transport.DoNotConfigureTopicEnabled = settings.DoNotConfigureTopicEnabled;
+            
+            Assert.That(transport.DoNotConfigureTopicEnabled, Is.True);
+        }
+        
+        [Test]
+        public void UseAzureServiceBusAsOneWayClient_WithDoNotConfigureTopic_SetsDoNotConfigureTopicEnabledToTrue()
+        {
+            var transport = new AzureServiceBusTransport(
+                AsbTestConfig.ConnectionString, 
+                null, 
+                _consoleLoggerFactory, 
+                new TplAsyncTaskFactory(_consoleLoggerFactory), 
+                new DefaultNameFormatter(), 
+                new AzureServiceBus.Messages.DefaultMessageConverter());
+            
+            Using(transport);
+            
+            var settings = new AzureServiceBusTransportClientSettings();
+            settings.DoNotConfigureTopic();
+            
+            transport.DoNotConfigureTopicEnabled = settings.DoNotConfigureTopicEnabled;
+            
+            Assert.That(transport.DoNotConfigureTopicEnabled, Is.True);
+        }
+        
+        [Test]
+        public void UseAzureServiceBus_KeepsDoNotConfigureTopicEnabled_FalseByDefault()
+        {
+            var transport = new AzureServiceBusTransport(
+                AsbTestConfig.ConnectionString, 
+                TestQueueName, 
+                _consoleLoggerFactory, 
+                new TplAsyncTaskFactory(_consoleLoggerFactory), 
+                new DefaultNameFormatter(), 
+                new AzureServiceBus.Messages.DefaultMessageConverter());
+            
+            Using(transport);
+            
+            transport.Initialize();
+            
+            Assert.That(transport.DoNotConfigureTopicEnabled, Is.False);
+        }
+        
+        [Test]
+        public void UseAzureServiceBusAsOneWayClient_KeepsDoNotConfigureTopicEnabled_FalseByDefault()
+        {
+            var transport = new AzureServiceBusTransport(
+                AsbTestConfig.ConnectionString, 
+                null, 
+                _consoleLoggerFactory, 
+                new TplAsyncTaskFactory(_consoleLoggerFactory), 
+                new DefaultNameFormatter(), 
+                new AzureServiceBus.Messages.DefaultMessageConverter());
+            
+            Using(transport);
+            
+            Assert.That(transport.DoNotConfigureTopicEnabled, Is.False);
+        }
+    }
+}

--- a/Rebus.AzureServiceBus.Tests/AzureServiceBusTransportClientSettingsDoNotConfigureTopicTest.cs
+++ b/Rebus.AzureServiceBus.Tests/AzureServiceBusTransportClientSettingsDoNotConfigureTopicTest.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using Rebus.Config;
+
+namespace Rebus.AzureServiceBus.Tests;
+
+[TestFixture]
+public class AzureServiceBusTransportClientSettingsDoNotConfigureTopicTest
+{
+    [Test]
+    public void DoNotConfigureTopic_SetsDoNotConfigureTopicEnabled_ToTrue()
+    {
+        var settings = new AzureServiceBusTransportClientSettings();
+        
+        settings.DoNotConfigureTopic();
+        
+        Assert.That(settings.DoNotConfigureTopicEnabled, Is.True);
+    }
+    
+    [Test]
+    public void DoNotConfigureTopicEnabled_IsFalse_ByDefault()
+    {
+        var settings = new AzureServiceBusTransportClientSettings();
+        
+        Assert.That(settings.DoNotConfigureTopicEnabled, Is.False);
+    }
+    
+    [Test]
+    public void DoNotConfigureTopic_ReturnsSelf_ForChaining()
+    {
+        var settings = new AzureServiceBusTransportClientSettings();
+        
+        var result = settings.DoNotConfigureTopic();
+        
+        Assert.That(result, Is.SameAs(settings));
+    }
+}

--- a/Rebus.AzureServiceBus.Tests/AzureServiceBusTransportDoNotConfigureTopicTest.cs
+++ b/Rebus.AzureServiceBus.Tests/AzureServiceBusTransportDoNotConfigureTopicTest.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.AzureServiceBus.NameFormat;
+using Rebus.Logging;
+using Rebus.Tests.Contracts;
+using Rebus.Threading.TaskParallelLibrary;
+
+namespace Rebus.AzureServiceBus.Tests;
+
+[TestFixture]
+public class AzureServiceBusTransportDoNotConfigureTopicTest : FixtureBase
+{
+    static readonly string TestQueueName = TestConfig.GetName("test-queue");
+    readonly ConsoleLoggerFactory _consoleLoggerFactory = new ConsoleLoggerFactory(false);
+        
+    [Test]
+    public async Task RegisterSubscriber_SkipsTopicConfiguration_WhenDoNotConfigureTopicEnabledIsTrue()
+    {
+        var transport = new AzureServiceBusTransport(
+            AsbTestConfig.ConnectionString, 
+            TestQueueName, 
+            _consoleLoggerFactory, 
+            new TplAsyncTaskFactory(_consoleLoggerFactory), 
+            new DefaultNameFormatter(), 
+            new AzureServiceBus.Messages.DefaultMessageConverter());
+            
+        Using(transport);
+            
+        transport.Initialize();
+        transport.DoNotConfigureTopicEnabled = true;
+            
+        await transport.RegisterSubscriber("test-topic", TestQueueName);
+            
+        Assert.Pass();
+    }
+        
+    [Test]
+    public async Task UnregisterSubscriber_SkipsTopicConfiguration_WhenDoNotConfigureTopicEnabledIsTrue()
+    {
+        var transport = new AzureServiceBusTransport(
+            AsbTestConfig.ConnectionString, 
+            TestQueueName, 
+            _consoleLoggerFactory, 
+            new TplAsyncTaskFactory(_consoleLoggerFactory), 
+            new DefaultNameFormatter(), 
+            new AzureServiceBus.Messages.DefaultMessageConverter());
+            
+        Using(transport);
+            
+        transport.Initialize();
+        transport.DoNotConfigureTopicEnabled = true;
+            
+        await transport.UnregisterSubscriber("test-topic", TestQueueName);
+            
+        Assert.Pass();
+    }
+}

--- a/Rebus.AzureServiceBus.Tests/AzureServiceBusTransportSettingsDoNotConfigureTopicTest.cs
+++ b/Rebus.AzureServiceBus.Tests/AzureServiceBusTransportSettingsDoNotConfigureTopicTest.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using Rebus.Config;
+
+namespace Rebus.AzureServiceBus.Tests;
+
+[TestFixture]
+public class AzureServiceBusTransportSettingsDoNotConfigureTopicTest
+{
+    [Test]
+    public void DoNotConfigureTopic_SetsDoNotConfigureTopicEnabled_ToTrue()
+    {
+        var settings = new AzureServiceBusTransportSettings();
+        
+        settings.DoNotConfigureTopic();
+        Assert.That(settings.DoNotConfigureTopicEnabled, Is.True);
+    }
+    
+    [Test]
+    public void DoNotConfigureTopicEnabled_IsFalse_ByDefault()
+    {
+        var settings = new AzureServiceBusTransportSettings();
+        Assert.That(settings.DoNotConfigureTopicEnabled, Is.False);
+    }
+    
+    [Test]
+    public void DoNotConfigureTopic_ReturnsSelf_ForChaining()
+    {
+        var settings = new AzureServiceBusTransportSettings();
+        
+        var result = settings.DoNotConfigureTopic();
+        Assert.That(result, Is.SameAs(settings));
+    }
+}

--- a/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
@@ -148,6 +148,11 @@ public class AzureServiceBusTransport : ITransport, IInitializable, IDisposable,
     /// </summary>
     public async Task RegisterSubscriber(string topic, string subscriberAddress)
     {
+        if (DoNotConfigureTopicEnabled)
+        {
+            return;
+        }
+        
         VerifyIsOwnInputQueueAddress(subscriberAddress);
 
         topic = _nameFormatter.FormatTopicName(topic);
@@ -182,6 +187,11 @@ public class AzureServiceBusTransport : ITransport, IInitializable, IDisposable,
     /// </summary>
     public async Task UnregisterSubscriber(string topic, string subscriberAddress)
     {
+        if (DoNotConfigureTopicEnabled)
+        {
+            return;
+        }
+        
         VerifyIsOwnInputQueueAddress(subscriberAddress);
 
         topic = _nameFormatter.FormatTopicName(topic);
@@ -784,6 +794,11 @@ public class AzureServiceBusTransport : ITransport, IInitializable, IDisposable,
     /// Gets/sets whether to skip checking queues configuration
     /// </summary>
     public bool DoNotCheckQueueConfigurationEnabled { get; set; }
+    
+    /// <summary>
+    /// Gets/sets whether to skip checking topics configuration
+    /// </summary>
+    public bool DoNotConfigureTopicEnabled { get; set; }
 
     /// <summary>
     /// Gets/sets the default message TTL. Must be set before calling <see cref="Initialize"/>, because that is the time when the queue is (re)configured

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusConfigurationExtensions.cs
@@ -58,7 +58,7 @@ public static class AzureServiceBusConfigurationExtensions
                     cancellationToken: cancellationToken,
                     tokenCredential: tokenCredential
                 );
-
+                transport.DoNotConfigureTopicEnabled = settingsBuilder.DoNotConfigureTopicEnabled;
                 return transport;
             });
 
@@ -108,6 +108,7 @@ public static class AzureServiceBusConfigurationExtensions
                 transport.DoNotCreateQueuesEnabled = settingsBuilder.DoNotCreateQueuesEnabled;
                 transport.DefaultMessageTimeToLive = settingsBuilder.DefaultMessageTimeToLive;
                 transport.DoNotCheckQueueConfigurationEnabled = settingsBuilder.DoNotCheckQueueConfigurationEnabled;
+                transport.DoNotConfigureTopicEnabled = settingsBuilder.DoNotConfigureTopicEnabled;
                 transport.LockDuration = settingsBuilder.LockDuration;
                 transport.AutoDeleteOnIdle = settingsBuilder.AutoDeleteOnIdle;
                 transport.DuplicateDetectionHistoryTimeWindow = settingsBuilder.DuplicateDetectionHistoryTimeWindow;

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportClientSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportClientSettings.cs
@@ -24,7 +24,24 @@ public class AzureServiceBusTransportClientSettings
     
     /// <summary>
     /// Skips topic verification. Can be used when the connection string does not have administration access
-    /// Should be careful, your topics should already have configured the forwards configurations
+    /// When enabled
+    /// - will not create the topic, subscription, or configure forwarding to the input queue.
+    /// - When needed subscribe method, will not delete the subscription for the specified topic.
+    ///
+    /// This flag is particularly useful in scenarios where:
+    /// - The application has only "Listen" permissions and lacks administrative rights to manage 
+    ///   topics and subscriptions in Azure Service Bus.
+    /// - The infrastructure is centrally managed, and topics/subscriptions are provisioned 
+    ///   manually or by deployment scripts.
+    /// - Security restrictions require more controlled and audited modifications to Service Bus entities.
+    ///
+    /// However, enabling this flag introduces the following considerations:
+    /// - <b>Manual Provisioning Required:</b> Topics, subscriptions, and forwarding must be manually configured 
+    ///   in the Azure Service Bus namespace.
+    /// - <b>Potential Message Loss:</b> If the subscription does not exist or is misconfigured, 
+    ///   messages will not be received and may be lost if not handled with a retry mechanism or DLQ (Dead Letter Queue).
+    /// - <b>Higher Maintenance Overhead:</b> Scaling or deploying new instances requires explicit verification 
+    ///   that all Service Bus entities are in place and correctly configured.
     /// </summary>
     public AzureServiceBusTransportClientSettings DoNotConfigureTopic()
     {

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportClientSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportClientSettings.cs
@@ -10,7 +10,7 @@ public class AzureServiceBusTransportClientSettings
     /// <summary>
     /// Gets/sets whether to skip checking topics configuration
     /// </summary>
-    public bool DoNotConfigureTopicEnabled { get; set; }
+    internal bool DoNotConfigureTopicEnabled { get; set; }
 
     /// <summary>
     /// Enables "legacy naming", which means that queue names are lowercased, and topic names are "normalized" to be in accordance

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportClientSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportClientSettings.cs
@@ -6,6 +6,11 @@
 public class AzureServiceBusTransportClientSettings
 {
     internal bool LegacyNamingEnabled { get; set; }
+    
+    /// <summary>
+    /// Gets/sets whether to skip checking topics configuration
+    /// </summary>
+    public bool DoNotConfigureTopicEnabled { get; set; }
 
     /// <summary>
     /// Enables "legacy naming", which means that queue names are lowercased, and topic names are "normalized" to be in accordance
@@ -14,6 +19,16 @@ public class AzureServiceBusTransportClientSettings
     public AzureServiceBusTransportClientSettings UseLegacyNaming()
     {
         LegacyNamingEnabled = true;
+        return this;
+    }
+    
+    /// <summary>
+    /// Skips topic verification. Can be used when the connection string does not have administration access
+    /// Should be careful, your topics should already have configured the forwards configurations
+    /// </summary>
+    public AzureServiceBusTransportClientSettings DoNotConfigureTopic()
+    {
+        DoNotConfigureTopicEnabled = true;
         return this;
     }
 }

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
@@ -16,6 +16,7 @@ public class AzureServiceBusTransportSettings
     internal bool DoNotCreateQueuesEnabled { get; set; }
     internal bool AutomaticPeekLockRenewalEnabled { get; set; }
     internal bool DoNotCheckQueueConfigurationEnabled { get; set; }
+    internal bool DoNotConfigureTopicEnabled { get; set; }
     internal bool LegacyNamingEnabled { get; set; }
     internal bool NativeMessageDeliveryCountEnabled { get; set; }
     internal TimeSpan? DefaultMessageTimeToLive { get; set; }
@@ -177,6 +178,16 @@ public class AzureServiceBusTransportSettings
     public AzureServiceBusTransportSettings DoNotCheckQueueConfiguration()
     {
         DoNotCheckQueueConfigurationEnabled = true;
+        return this;
+    }
+    
+    /// <summary>
+    /// Skips topic verification. Can be used when the connection string does not have administration access
+    /// Should be careful, your topics should already have configured the forwards configurations
+    /// </summary>
+    public AzureServiceBusTransportSettings DoNotConfigureTopic()
+    {
+        DoNotConfigureTopicEnabled = true;
         return this;
     }
 

--- a/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
+++ b/Rebus.AzureServiceBus/Config/AzureServiceBusTransportSettings.cs
@@ -183,7 +183,24 @@ public class AzureServiceBusTransportSettings
     
     /// <summary>
     /// Skips topic verification. Can be used when the connection string does not have administration access
-    /// Should be careful, your topics should already have configured the forwards configurations
+    /// When enabled
+    /// - will not create the topic, subscription, or configure forwarding to the input queue.
+    /// - When needed subscribe method, will not delete the subscription for the specified topic.
+    ///
+    /// This flag is particularly useful in scenarios where:
+    /// - The application has only "Listen" permissions and lacks administrative rights to manage 
+    ///   topics and subscriptions in Azure Service Bus.
+    /// - The infrastructure is centrally managed, and topics/subscriptions are provisioned 
+    ///   manually or by deployment scripts.
+    /// - Security restrictions require more controlled and audited modifications to Service Bus entities.
+    ///
+    /// However, enabling this flag introduces the following considerations:
+    /// - <b>Manual Provisioning Required:</b> Topics, subscriptions, and forwarding must be manually configured 
+    ///   in the Azure Service Bus namespace.
+    /// - <b>Potential Message Loss:</b> If the subscription does not exist or is misconfigured, 
+    ///   messages will not be received and may be lost if not handled with a retry mechanism or DLQ (Dead Letter Queue).
+    /// - <b>Higher Maintenance Overhead:</b> Scaling or deploying new instances requires explicit verification 
+    ///   that all Service Bus entities are in place and correctly configured.
     /// </summary>
     public AzureServiceBusTransportSettings DoNotConfigureTopic()
     {


### PR DESCRIPTION
# Add option to disable topic configuration in Azure Service Bus

## Changes made

This PR adds the `DoNotConfigureTopic()` functionality to the Azure Service Bus transport, allowing users to disable automatic topic configuration. This is especially useful in scenarios where the connection does not have administrative permissions to create or modify topics.

### Technical details:

1. **AzureServiceBusTransport**:
   - Added the `DoNotConfigureTopicEnabled` property
   - Modified the `RegisterSubscriber` and `UnregisterSubscriber` methods to return immediately when `DoNotConfigureTopicEnabled` is true

2. **AzureServiceBusConfigurationExtensions**:
   - Added the configuration of the `DoNotConfigureTopicEnabled` property in the `UseAzureServiceBus` and `UseAzureServiceBusAsOneWayClient` methods

3. **AzureServiceBusTransportSettings** and **AzureServiceBusTransportClientSettings**:
   - Added the `DoNotConfigureTopicEnabled` property
   - Added the `DoNotConfigureTopic()` method to enable the functionality

4. **Tests**:
   - Added tests to verify the behavior of the new functionality

## Motivation

In production environments, connections to Azure Service Bus often have limited permissions for security reasons. Previously, when the transport tried to configure topics without having the necessary permissions, errors occurred that prevented the application from functioning correctly.

This change allows applications to work with connections that have only read/write permissions on queues and topics, without requiring administrative permissions to create or modify resources in Azure Service Bus.

## How to use

To disable automatic topic configuration, simply add the `DoNotConfigureTopic()` method in the transport configuration:

```csharp
Configure.With(activator)
    .Transport(t => t.UseAzureServiceBus(connectionString, "input-queue")
        .DoNotConfigureTopic())
    .Start();
```

Or for one-way clients:

```csharp
Configure.OneWayClient()
    .Transport(t => t.UseAzureServiceBusAsOneWayClient(connectionString)
        .DoNotConfigureTopic())
    .Start();
```

**Note:** I added a clear summary because if we do that, we might encounter some issues with the forwarding.
However, if the forwarding is already configured, it shouldn't be a problem.