### PR TITLE
Fixed Not Configure Topic Missing to send message

### DIFF
--- a/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
+++ b/Rebus.AzureServiceBus/AzureServiceBus/AzureServiceBusTransport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -150,6 +150,7 @@ public class AzureServiceBusTransport : ITransport, IInitializable, IDisposable,
     {
         if (DoNotConfigureTopicEnabled)
         {
+            _log.Info("Transport configured to not configure topic - skipping configuration for topic {topicName}", topic);
             return;
         }
         
@@ -189,6 +190,7 @@ public class AzureServiceBusTransport : ITransport, IInitializable, IDisposable,
     {
         if (DoNotConfigureTopicEnabled)
         {
+            _log.Info("Transport configured to not configure topic - skipping configuration for topic {topicName}", topic);
             return;
         }
         
@@ -913,7 +915,10 @@ public class AzureServiceBusTransport : ITransport, IInitializable, IDisposable,
 
     async Task<ServiceBusSender> GetTopicClient(string topic) => await _topicClients.GetOrAdd(topic, _ => new(async () =>
     {
-        await EnsureTopicExists(topic);
+        if(!DoNotConfigureTopicEnabled)
+        {
+            await EnsureTopicExists(topic);
+        }
 
         var topicClient = _client.CreateSender(topic);
 


### PR DESCRIPTION

I think in the last implementation missed to disable admin when send messages.

- Added to check configureTopic when send a message.
- Added log information about disabled configuration



---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
