### PR TITLE
#111 Removed potentially duplicate dead letter message headers

### DIFF
--- a/Rebus.AzureServiceBus/Config/AdditionalAzureServiceBusConfigurationExtensions.cs
+++ b/Rebus.AzureServiceBus/Config/AdditionalAzureServiceBusConfigurationExtensions.cs
@@ -65,6 +65,9 @@ public static class AdditionalAzureServiceBusConfigurationExtensions
                 {
                     messageId = "<unknown>";
                 }
+                
+                transportMessage.Headers.Remove("DeadLetterReason");
+                transportMessage.Headers.Remove("DeadLetterErrorDescription");
 
                 _log.Error("Dead-lettering message with ID {messageId}, reason={deadLetterReason}, exception info: {exceptionInfo}",
                     messageId, deadLetterReason, exception);


### PR DESCRIPTION
This addresses issue https://github.com/rebus-org/Rebus.AzureServiceBus/issues/111

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
